### PR TITLE
feat(editor): implement Select All

### DIFF
--- a/packages/editor/src/models/Document.ts
+++ b/packages/editor/src/models/Document.ts
@@ -166,6 +166,39 @@ export class Document {
     }
   }
 
+  selectAll(): void {
+    const { selectedComponents, selectedInstances } = this;
+    this.deselect();
+
+    if (!selectedComponents.length && selectedInstances.length) {
+      const parents = new Set<ElementInstance | Component>();
+      for (const instance of selectedInstances) {
+        if (instance.parent) {
+          parents.add(instance.parent);
+        } else if (instance.node.component) {
+          parents.add(instance.node.component);
+        }
+      }
+
+      for (const parent of parents) {
+        if (parent instanceof Component) {
+          for (const variant of parent.allVariants) {
+            variant.rootInstance?.select();
+          }
+        } else {
+          for (const child of parent.children) {
+            child.select();
+          }
+        }
+      }
+      return;
+    }
+
+    for (const component of this.components.children) {
+      component.select();
+    }
+  }
+
   renameTagNameUsages(oldTagName: string, newTagName: string): void {
     const elementsToRename: Element[] = [];
 

--- a/packages/editor/src/state/Commands.ts
+++ b/packages/editor/src/state/Commands.ts
@@ -116,6 +116,20 @@ export class Commands {
     });
   }
 
+  @computed get selectAll(): Command {
+    return withAnalytics({
+      text: "Select All",
+      shortcut: [new KeyGesture(["Command"], "KeyA")],
+      onClick: action(() => {
+        if (isTextInputFocused()) {
+          return false;
+        }
+        this.document.selectAll();
+        return true;
+      }),
+    });
+  }
+
   @computed get copyStyle(): Command {
     return withAnalytics({
       text: "Copy Style",

--- a/packages/editor/src/state/EditorState.tsx
+++ b/packages/editor/src/state/EditorState.tsx
@@ -135,6 +135,7 @@ export abstract class EditorState {
       this.commands.copy,
       this.commands.paste,
       this.commands.delete,
+      this.commands.selectAll,
     ];
   }
 


### PR DESCRIPTION
Command+A to select all siblings

Fix #67 