### PR TITLE
fix(figma): export better CSS from Figma

### DIFF
--- a/packages/figma/README.md
+++ b/packages/figma/README.md
@@ -1,6 +1,6 @@
 # Figma plugin for Macaron
 
-Copy & paste Figma layers into [Macaron](https://macaron-elements.com/).
+Copy & paste Figma layers into [Macaron](https://macaron-elements.com/), a visual editor for creating Web Components.
 
 - Select layers you want to copy
 - Open the plugin

--- a/packages/figma/package.json
+++ b/packages/figma/package.json
@@ -24,7 +24,7 @@
     "svg-parser": "^2.0.4"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "*",
+    "@figma/plugin-typings": "^1.49.0",
     "@macaron-elements/loader-vite": "*",
     "concurrently": "^7.2.2",
     "esbuild": "^0.14.47",

--- a/packages/figma/plugin-src/style.ts
+++ b/packages/figma/plugin-src/style.ts
@@ -123,9 +123,7 @@ export function layoutStyle(node: BaseFrameMixin): Style {
   return style;
 }
 
-export function fillBorderStyle(
-  node: GeometryMixin & RectangleCornerMixin
-): Style {
+export function fillBorderStyle(node: BaseFrameMixin): Style {
   // TODO: A rectangle with single image fill should be treated as <img> rather than <div> with a background image
 
   // TODO: support multiple fills

--- a/packages/figma/plugin-src/style.ts
+++ b/packages/figma/plugin-src/style.ts
@@ -120,6 +120,10 @@ export function layoutStyle(node: BaseFrameMixin): Style {
     }
   }
 
+  if (node.clipsContent) {
+    style.overflow = "hidden";
+  }
+
   return style;
 }
 

--- a/packages/figma/plugin-src/style.ts
+++ b/packages/figma/plugin-src/style.ts
@@ -136,39 +136,26 @@ export function fillBorderStyle(node: BaseFrameMixin): Style {
 
   const borderColor =
     stroke?.type === "SOLID" ? solidPaintToHex(stroke) : undefined;
-  const borderTopWidth =
-    borderColor && node.strokeTopWeight
-      ? String(node.strokeTopWeight)
-      : undefined;
-  const borderRightWidth =
-    borderColor && node.strokeRightWeight
-      ? String(node.strokeRightWeight)
-      : undefined;
-  const borderBottomWidth =
-    borderColor && node.strokeBottomWeight
-      ? String(node.strokeBottomWeight)
-      : undefined;
-  const borderLeftWidth =
-    borderColor && node.strokeLeftWeight
-      ? String(node.strokeLeftWeight)
-      : undefined;
-
   const borderStyle = borderColor ? "solid" : undefined;
 
   return {
     background,
-    borderTopStyle: borderStyle,
-    borderRightStyle: borderStyle,
-    borderBottomStyle: borderStyle,
-    borderLeftStyle: borderStyle,
-    borderTopWidth,
-    borderRightWidth,
-    borderBottomWidth,
-    borderLeftWidth,
-    borderTopColor: borderColor,
-    borderRightColor: borderColor,
-    borderBottomColor: borderColor,
-    borderLeftColor: borderColor,
+    ...(borderStyle === "solid"
+      ? {
+          borderTopStyle: borderStyle,
+          borderRightStyle: borderStyle,
+          borderBottomStyle: borderStyle,
+          borderLeftStyle: borderStyle,
+          borderTopWidth: `${node.strokeTopWeight}px`,
+          borderRightWidth: `${node.strokeRightWeight}px`,
+          borderBottomWidth: `${node.strokeBottomWeight}px`,
+          borderLeftWidth: `${node.strokeLeftWeight}px`,
+          borderTopColor: borderColor,
+          borderRightColor: borderColor,
+          borderBottomColor: borderColor,
+          borderLeftColor: borderColor,
+        }
+      : {}),
     borderTopLeftRadius:
       node.topLeftRadius !== 0 ? `${node.topLeftRadius}px` : undefined,
     borderTopRightRadius:

--- a/packages/figma/plugin-src/style.ts
+++ b/packages/figma/plugin-src/style.ts
@@ -11,7 +11,10 @@ export function positionStyle(
   const style: Style = {};
 
   // TODO: more constraints
-  if (parentLayout === "NONE") {
+  if (
+    parentLayout === "NONE" ||
+    ("layoutPositioning" in node && node.layoutPositioning === "ABSOLUTE")
+  ) {
     style.position = "absolute";
     style.left = `${node.x - groupTopLeft.x}px`;
     style.top = `${node.y - groupTopLeft.y}px`;

--- a/packages/figma/plugin-src/style.ts
+++ b/packages/figma/plugin-src/style.ts
@@ -136,20 +136,35 @@ export function fillBorderStyle(node: BaseFrameMixin): Style {
 
   const borderColor =
     stroke?.type === "SOLID" ? solidPaintToHex(stroke) : undefined;
-  const borderWidth =
-    borderColor && node.strokeWeight ? String(node.strokeWeight) : undefined;
+  const borderTopWidth =
+    borderColor && node.strokeTopWeight
+      ? String(node.strokeTopWeight)
+      : undefined;
+  const borderRightWidth =
+    borderColor && node.strokeRightWeight
+      ? String(node.strokeRightWeight)
+      : undefined;
+  const borderBottomWidth =
+    borderColor && node.strokeBottomWeight
+      ? String(node.strokeBottomWeight)
+      : undefined;
+  const borderLeftWidth =
+    borderColor && node.strokeLeftWeight
+      ? String(node.strokeLeftWeight)
+      : undefined;
+
   const borderStyle = borderColor ? "solid" : undefined;
 
   return {
-    background: background,
+    background,
     borderTopStyle: borderStyle,
     borderRightStyle: borderStyle,
     borderBottomStyle: borderStyle,
     borderLeftStyle: borderStyle,
-    borderTopWidth: borderWidth,
-    borderRightWidth: borderWidth,
-    borderBottomWidth: borderWidth,
-    borderLeftWidth: borderWidth,
+    borderTopWidth,
+    borderRightWidth,
+    borderBottomWidth,
+    borderLeftWidth,
     borderTopColor: borderColor,
     borderRightColor: borderColor,
     borderBottomColor: borderColor,

--- a/packages/figma/plugin-src/traverse.ts
+++ b/packages/figma/plugin-src/traverse.ts
@@ -122,10 +122,17 @@ export async function figmaToMacaron(
         ...compact(
           await Promise.all(
             node.children.map((child) =>
-              figmaToMacaron(idGenerator, child, node.layoutMode, {
-                x: node.strokeLeftWeight,
-                y: node.strokeTopWeight,
-              })
+              figmaToMacaron(
+                idGenerator,
+                child,
+                node.layoutMode,
+                node.strokes.length
+                  ? {
+                      x: node.strokeLeftWeight,
+                      y: node.strokeTopWeight,
+                    }
+                  : { x: 0, y: 0 }
+              )
             )
           )
         )

--- a/packages/figma/plugin-src/traverse.ts
+++ b/packages/figma/plugin-src/traverse.ts
@@ -32,6 +32,11 @@ export async function figmaToMacaron(
     return undefined;
   }
 
+  // ignore mask layers
+  if ("isMask" in node && node.isMask) {
+    return undefined;
+  }
+
   if (isVectorLikeNode(node)) {
     try {
       const svg = await node.exportAsync({ format: "SVG" });

--- a/packages/figma/plugin-src/traverse.ts
+++ b/packages/figma/plugin-src/traverse.ts
@@ -122,7 +122,10 @@ export async function figmaToMacaron(
         ...compact(
           await Promise.all(
             node.children.map((child) =>
-              figmaToMacaron(idGenerator, child, node.layoutMode)
+              figmaToMacaron(idGenerator, child, node.layoutMode, {
+                x: node.strokeLeftWeight,
+                y: node.strokeTopWeight,
+              })
             )
           )
         )

--- a/packages/figma/plugin-src/traverse.ts
+++ b/packages/figma/plugin-src/traverse.ts
@@ -37,6 +37,30 @@ export async function figmaToMacaron(
     return undefined;
   }
 
+  // Image like node
+  if (
+    node.type == "RECTANGLE" &&
+    node.fills !== figma.mixed &&
+    node.fills.length
+  ) {
+    const fill = node.fills[0];
+    if (fill.type === "IMAGE" && fill.imageHash) {
+      const image = figma.getImageByHash(fill.imageHash);
+      const dataURL = image
+        ? imageToDataURL(await image.getBytesAsync())
+        : undefined;
+
+      return h("img", {
+        id,
+        src: dataURL,
+        style: stringifyStyle({
+          ...positionStyle(node, parentLayout, groupTopLeft),
+          ...effectStyle(node),
+        }),
+      });
+    }
+  }
+
   if (isVectorLikeNode(node)) {
     try {
       const svg = await node.exportAsync({ format: "SVG" });
@@ -66,35 +90,6 @@ export async function figmaToMacaron(
   }
 
   switch (node.type) {
-    case "RECTANGLE": {
-      if (node.fills !== figma.mixed && node.fills.length) {
-        const fill = node.fills[0];
-        if (fill.type === "IMAGE" && fill.imageHash) {
-          const image = figma.getImageByHash(fill.imageHash);
-          const dataURL = image
-            ? imageToDataURL(await image.getBytesAsync())
-            : undefined;
-
-          return h("img", {
-            id,
-            src: dataURL,
-            style: stringifyStyle({
-              ...positionStyle(node, parentLayout, groupTopLeft),
-              ...effectStyle(node),
-            }),
-          });
-        }
-      }
-
-      return h("div", {
-        id,
-        style: stringifyStyle({
-          ...fillBorderStyle(node),
-          ...positionStyle(node, parentLayout, groupTopLeft),
-          ...effectStyle(node),
-        }),
-      });
-    }
     case "TEXT": {
       return h(
         "div",

--- a/packages/figma/plugin-src/util.ts
+++ b/packages/figma/plugin-src/util.ts
@@ -40,6 +40,7 @@ export function rgbaToHex(rgba: RGBA): string {
 
 const vectorLikeTypes: SceneNode["type"][] = [
   "LINE",
+  "RECTANGLE",
   "ELLIPSE",
   "POLYGON",
   "STAR",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,10 +1451,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@figma/plugin-typings@*":
-  version "1.47.0"
-  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.47.0.tgz#cc6345b1611a156228655c0869c87953cd1ec868"
-  integrity sha512-DwMHzjDvks2cRWOTz4JRXqh+PZ2YP71MAdegw6qTqjjpACIWQGfuiFPrO2duoqB8pY1mMZsBK8xqozF2LIr7Kw==
+"@figma/plugin-typings@^1.49.0":
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.49.0.tgz#5bd88d1c2f38a69854330ad7b6d6e9ac6f8816c7"
+  integrity sha512-72tKC61RPkrBZ+uzj+TtL3bVAmxahZKv/TfElbrY9sBoZvr4/+4gw7hnJYiln5xBJHiJ4KTcjUy+6D1qUuWlTA==
 
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"


### PR DESCRIPTION
- [x] Support absolute positions
- [x] Support separate border widths
- [x] Export rectangles as SVGs
- [x] Ignore mask layers
- [x] Adjust absolute positions based on parent border widths
- [ ] Support hiding overflow